### PR TITLE
Update qbittorrent.conf

### DIFF
--- a/Apps/qbittorrent.conf
+++ b/Apps/qbittorrent.conf
@@ -14,7 +14,7 @@ location /qbt/ {
 location ^~ /qbt/api {
     auth_request off;
     rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:38086;
+    proxy_pass http://127.0.0.1:8080;
 }
 location ^~ /qbt/command {
     auth_request off;

--- a/Apps/qbittorrent.conf
+++ b/Apps/qbittorrent.conf
@@ -4,45 +4,45 @@ location /qbt/ {
     #Org Auth
     #auth_request /auth-0;   #=Admin
     
-    proxy_pass              http://192.168.1.4:38086/;
-	#include C:/nginx/conf/proxy.conf;
+    proxy_pass              http://127.0.0.1:8080/;
+    #include C:/nginx/conf/proxy.conf;
     proxy_set_header        X-Forwarded-Host        $server_name:$server_port;
     proxy_hide_header       Referer;
     proxy_hide_header       Origin;
     proxy_set_header        Referer                 '';
     proxy_set_header        Origin                  '';
     #add_header              X-Frame-Options         "SAMEORIGIN"; #See comment at the end
-	
-#nzb360 Auth off
-		location ^~ /qbt/api {
-			auth_request off;
-			rewrite /qbt(.*) $1 break;
-			proxy_pass http://192.168.1.4:38086;
-		}
-		
-		location ^~ /qbt/command {
-			auth_request off;
-			rewrite /qbt(.*) $1 break;
-			proxy_pass http://192.168.1.4:38086;
-		}
+    
+    #nzb360 Auth off
+    location ^~ /qbt/api {
+        auth_request off;
+        rewrite /qbt(.*) $1 break;
+        proxy_pass http://127.0.0.1:8080;
+    }
+    
+    location ^~ /qbt/command {
+        auth_request off;
+        rewrite /qbt(.*) $1 break;
+        proxy_pass http://127.0.0.1:8080;
+    }
 
-		location ^~ /qbt/query {
-			auth_request off;
-			rewrite /qbt(.*) $1 break;
-			proxy_pass http://192.168.1.4:38086;
-		}
-		
-		location ^~ /qbt/login {
-			auth_request off;
-			rewrite /qbt(.*) $1 break;
-			proxy_pass http://192.168.1.4:38086;
-		}
-		
-		location ^~ /qbt/sync {
-			auth_request off;
-			rewrite /qbt(.*) $1 break;
-			proxy_pass http://192.168.1.4:38086;
-		}
+    location ^~ /qbt/query {
+        auth_request off;
+        rewrite /qbt(.*) $1 break;
+        proxy_pass http://127.0.0.1:8080;
+    }
+    
+    location ^~ /qbt/login {
+        auth_request off;
+        rewrite /qbt(.*) $1 break;
+        proxy_pass http://127.0.0.1:8080;
+    }
+    
+    location ^~ /qbt/sync {
+        auth_request off;
+        rewrite /qbt(.*) $1 break;
+        proxy_pass http://127.0.0.1:8080;
+    }
 }
 
 ## Note: For some users, several windows in the Web UI will still be blank, such as when adding a new torrent from a URL/magnet or local file.

--- a/Apps/qbittorrent.conf
+++ b/Apps/qbittorrent.conf
@@ -1,41 +1,46 @@
-# qBittorrent reverse proxy location block
-
+#qBittorrent Reverse Proxy
 location /qbt/ {
-    proxy_pass              http://127.0.0.1:8080/;
+    
+    #Org Auth
+    #auth_request /auth-0;   #=Admin
+    
+    proxy_pass              http://192.168.1.4:38086/;
+	#include C:/nginx/conf/proxy.conf;
     proxy_set_header        X-Forwarded-Host        $server_name:$server_port;
     proxy_hide_header       Referer;
     proxy_hide_header       Origin;
     proxy_set_header        Referer                 '';
     proxy_set_header        Origin                  '';
-    add_header              X-Frame-Options         "SAMEORIGIN"; # see note
-}
+    add_header              X-Frame-Options         "SAMEORIGIN";
+	
+#nzb360 Auth off
+		location ^~ /qbt/api {
+			auth_request off;
+			rewrite /qbt(.*) $1 break;
+			proxy_pass http://192.168.1.4:38086;
+		}
+		
+		location ^~ /qbt/command {
+			auth_request off;
+			rewrite /qbt(.*) $1 break;
+			proxy_pass http://192.168.1.4:38086;
+		}
 
-# NZB360 Auth off
-location ^~ /qbt/api {
-    auth_request off;
-    rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:8080;
+		location ^~ /qbt/query {
+			auth_request off;
+			rewrite /qbt(.*) $1 break;
+			proxy_pass http://192.168.1.4:38086;
+		}
+		
+		location ^~ /qbt/login {
+			auth_request off;
+			rewrite /qbt(.*) $1 break;
+			proxy_pass http://192.168.1.4:38086;
+		}
+		
+		location ^~ /qbt/sync {
+			auth_request off;
+			rewrite /qbt(.*) $1 break;
+			proxy_pass http://192.168.1.4:38086;
+		}
 }
-location ^~ /qbt/command {
-    auth_request off;
-    rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:8080;
-}
-location ^~ /qbt/query {
-    auth_request off;
-    rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:8080;
-}
-location ^~ /qbt/login {
-    auth_request off;
-    rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:8080;
-}
-location ^~ /qbt/sync {
-    auth_request off;
-    rewrite /qbt(.*) $1 break;
-    proxy_pass http://127.0.0.1:8080;
-}
-## Note: For some users, several windows in the Web UI will still be blank, such as when adding a new torrent from a URL/magnet or local file.
-## If so, try adding the following line to the location block:
-## add_header X-Frame-Options "SAMEORIGIN";

--- a/Apps/qbittorrent.conf
+++ b/Apps/qbittorrent.conf
@@ -11,7 +11,7 @@ location /qbt/ {
     proxy_hide_header       Origin;
     proxy_set_header        Referer                 '';
     proxy_set_header        Origin                  '';
-    add_header              X-Frame-Options         "SAMEORIGIN";
+    #add_header              X-Frame-Options         "SAMEORIGIN"; #See comment at the end
 	
 #nzb360 Auth off
 		location ^~ /qbt/api {
@@ -44,3 +44,7 @@ location /qbt/ {
 			proxy_pass http://192.168.1.4:38086;
 		}
 }
+
+## Note: For some users, several windows in the Web UI will still be blank, such as when adding a new torrent from a URL/magnet or local file.
+## If so, try adding the following line to the location block:
+## add_header X-Frame-Options "SAMEORIGIN";

--- a/Apps/qbittorrent.conf
+++ b/Apps/qbittorrent.conf
@@ -10,6 +10,32 @@ location /qbt/ {
     add_header              X-Frame-Options         "SAMEORIGIN"; # see note
 }
 
+# NZB360 Auth off
+location ^~ /qbt/api {
+    auth_request off;
+    rewrite /qbt(.*) $1 break;
+    proxy_pass http://127.0.0.1:38086;
+}
+location ^~ /qbt/command {
+    auth_request off;
+    rewrite /qbt(.*) $1 break;
+    proxy_pass http://127.0.0.1:8080;
+}
+location ^~ /qbt/query {
+    auth_request off;
+    rewrite /qbt(.*) $1 break;
+    proxy_pass http://127.0.0.1:8080;
+}
+location ^~ /qbt/login {
+    auth_request off;
+    rewrite /qbt(.*) $1 break;
+    proxy_pass http://127.0.0.1:8080;
+}
+location ^~ /qbt/sync {
+    auth_request off;
+    rewrite /qbt(.*) $1 break;
+    proxy_pass http://127.0.0.1:8080;
+}
 ## Note: For some users, several windows in the Web UI will still be blank, such as when adding a new torrent from a URL/magnet or local file.
 ## If so, try adding the following line to the location block:
 ## add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
This reverse proxy configuration will allow the usage of QBitTorrent with nzb360.

However, Halian and I are still looking into what other possible attack vectors are created by removing the Org Auth from those areas.