### PR TITLE
Allow loading of fonts and glyphs in the Calibre CaliBlur theme

### DIFF
--- a/Apps/calibre.conf
+++ b/Apps/calibre.conf
@@ -5,4 +5,5 @@ location /calibre {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Scheme $scheme;
         proxy_set_header X-Script-Name /calibre;
+        add_header Content-Security-Policy "font-src 'self' data:;" always;
 }


### PR DESCRIPTION
Fixes console error: Refused to load the font 'data:application........' because it violates the following Content Security Policy directive: "default-src` `'self'". Note that 'font-src' was not explicitly set, so 'default-src' is used as a fallback.